### PR TITLE
Add PLAN.md for scaffolding minimal Expo app

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -19,29 +19,29 @@ Scaffold the bare-bones boilerplate code for a minimal React Native app using Ex
 Run the following command (per [React Native docs](https://reactnative.dev/docs/environment-setup)):
 
 ```sh
-npx create-expo-app@latest simple-react-native-app --template blank
+npx create-expo-app@latest simple-react-native-app
 ```
 
-The `blank` template gives a single `App.js` with minimal boilerplate — no navigation, no tabs, no extra screens.
+The default template provides a minimal starting point. If the generated project includes file-based routing or extra screens, simplify it down to a single screen with a welcome message.
 
 ### Step 2: Verify key files exist
 
 After initialization, confirm these files are present:
 
-- `App.js` — Single entry point with a functional component
-- `app.json` — Expo configuration (app name, platforms, icons)
+- `app.json` or `app.config.js` — Expo configuration (app name, platforms, icons)
 - `package.json` — Dependencies (`expo`, `react`, `react-native`)
-- `babel.config.js` — Babel preset for Expo
+
+> **Note:** The default template may use file-based routing with an `app/` directory instead of a single `App.js`. Either structure works — the goal is to end up with a single minimal screen.
 
 ### Step 3: Keep App.js minimal
 
-`App.js` should contain only the essential core components (per [React Native Core Components docs](https://reactnative.dev/docs/components-and-apis)):
+The main screen component should contain only the essential core components (per [React Native Core Components docs](https://reactnative.dev/docs/components-and-apis)):
 
 - **`View`** — The fundamental container component (maps to `ViewGroup` on Android, `UIView` on iOS, `<div>` on web)
 - **`Text`** — For displaying text (maps to `TextView` on Android, `UITextView` on iOS, `<p>` on web)
 - **`StyleSheet`** — Abstraction layer for styling, similar to CSS stylesheets
 
-Example minimal `App.js`:
+Example minimal screen component:
 
 ```jsx
 import { StatusBar } from 'expo-status-bar';
@@ -85,15 +85,15 @@ Confirm the app renders a centered welcome message in the browser.
 - No navigation or routing
 - No additional screens or components
 - No third-party dependencies beyond what Expo provides
-- No TypeScript conversion (unless the template includes it)
+- No TypeScript conversion required (the default template may already use TypeScript, which is fine)
 - No custom fonts, icons, or assets
 - No testing framework setup
 - No linting or formatting configuration
 
 ## Done Criteria
 
-- [ ] `App.js` contains a single functional component with `View`, `Text`, and `StyleSheet`
-- [ ] `app.json` is configured with the app name
-- [ ] `package.json` lists only `expo`, `react`, and `react-native` as dependencies
+- [ ] Main screen contains a single functional component with `View`, `Text`, and `StyleSheet`
+- [ ] `app.json` (or `app.config.js`) is configured with the app name
+- [ ] `package.json` lists only `expo`, `react`, and `react-native` as core dependencies
 - [ ] App renders on web via `npx expo start --web`
 - [ ] No unnecessary files or dependencies exist


### PR DESCRIPTION
Adds a PLAN.md file with step-by-step instructions and verified official doc references for scaffolding the bare-bones Expo app.

Closes #5

Generated with [Claude Code](https://claude.ai/code)